### PR TITLE
QueuedApnsService critical fix

### DIFF
--- a/src/main/java/com/notnoop/apns/internal/QueuedApnsService.java
+++ b/src/main/java/com/notnoop/apns/internal/QueuedApnsService.java
@@ -36,12 +36,17 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.notnoop.apns.ApnsNotification;
 import com.notnoop.apns.ApnsService;
 import com.notnoop.exceptions.NetworkIOException;
 
 public class QueuedApnsService extends AbstractApnsService {
 
+	private static final Logger logger = LoggerFactory.getLogger(QueuedApnsService.class);
+	
     private ApnsService service;
     private BlockingQueue<ApnsNotification> queue;
     private AtomicBoolean started = new AtomicBoolean(false);
@@ -81,6 +86,12 @@ public class QueuedApnsService extends AbstractApnsService {
                         ApnsNotification msg = queue.take();
                         service.push(msg);
                     } catch (InterruptedException e) {
+                    	// ignore
+                    } catch (NetworkIOException e) {
+                    	// ignore: failed connect...
+                    } catch (Exception e) {
+                    	// weird if we reached here - something wrong is happening, but we shouldn't stop the service anyway!
+                    	logger.warn("Unexpected message caught... Shouldn't be here", e);
                     }
                 }
             }


### PR DESCRIPTION
Do not stop QueuedApnsService on three unsuccessfull attempts to submit the same message.
