### PR TITLE
Make APNS.java final

### DIFF
--- a/src/main/java/com/notnoop/apns/APNS.java
+++ b/src/main/java/com/notnoop/apns/APNS.java
@@ -37,7 +37,7 @@ package com.notnoop.apns;
  * {@code ApnsNotification} payload.
  *
  */
-public class APNS {
+public final class APNS {
 
     private APNS() { throw new AssertionError("Uninstantiable class"); }
 


### PR DESCRIPTION
Since the class has only one private CTOR, you can't extend it anyways, so let's make it final
