### PR TITLE
Fix URL to CHANGELOG

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -13,7 +13,7 @@ connections or JSON library if necessary.
 
 Links: [Installation](http://wiki.github.com/notnoop/java-apns/installation)
 - [Javadocs](http://notnoop.github.com/java-apns/apidocs/index.html)
-- [Changelog](java-apns/blob/master/CHANGELOG)
+- [Changelog](CHANGELOG)
 
 Features:
 --------------


### PR DESCRIPTION
Wrong URL:
https://github.com/notnoop/java-apns/blob/master/java-apns/blob/master/CHANGELOG

Right URL
https://github.com/notnoop/java-apns/blob/master/CHANGELOG
