### PR TITLE
Add a configuration parameter to set the read timeout in sockets before reading data from them.

### DIFF
--- a/src/main/java/com/notnoop/apns/ApnsServiceBuilder.java
+++ b/src/main/java/com/notnoop/apns/ApnsServiceBuilder.java
@@ -74,6 +74,8 @@ public class ApnsServiceBuilder {
 
     private SSLContext sslContext;
 
+    private int readTimeout = 0;
+
     private String gatewayHost;
     private int gatewaPort = -1;
 
@@ -216,6 +218,17 @@ public class ApnsServiceBuilder {
     public ApnsServiceBuilder withSSLContext(SSLContext sslContext) {
         this.sslContext = sslContext;
         return this;
+    }
+    
+    /**
+     * Specify the timeout value to be set in new setSoTimeout in created
+     * sockets, for both feedback and push connections, in msecs.
+     * @param readTimeout
+     * @return
+     */
+    public ApnsServiceBuilder withReadTimeout(int readTimeout) {
+    	this.readTimeout = readTimeout;
+    	return this;
     }
 
     /**
@@ -536,11 +549,11 @@ public class ApnsServiceBuilder {
         ApnsService service;
 
         SSLSocketFactory sslFactory = sslContext.getSocketFactory();
-        ApnsFeedbackConnection feedback = new ApnsFeedbackConnection(sslFactory, feedbackHost, feedbackPort, proxy);
+        ApnsFeedbackConnection feedback = new ApnsFeedbackConnection(sslFactory, feedbackHost, feedbackPort, proxy, readTimeout);
 
         ApnsConnection conn = new ApnsConnectionImpl(sslFactory, gatewayHost, 
                 gatewaPort, proxy, reconnectPolicy, 
-                delegate, errorDetection, cacheLength, autoAdjustCacheLength);
+                delegate, errorDetection, cacheLength, autoAdjustCacheLength, readTimeout);
         if (pooledMax != 1) {
             conn = new ApnsPooledConnection(conn, pooledMax, executor);
         }

--- a/src/main/java/com/notnoop/apns/internal/ApnsConnectionImpl.java
+++ b/src/main/java/com/notnoop/apns/internal/ApnsConnectionImpl.java
@@ -60,6 +60,7 @@ public class ApnsConnectionImpl implements ApnsConnection {
     private final SocketFactory factory;
     private final String host;
     private final int port;
+    private final int readTimeout;
     private final Proxy proxy;
     private final ReconnectPolicy reconnectPolicy;
     private final ApnsDelegate delegate;
@@ -83,13 +84,13 @@ public class ApnsConnectionImpl implements ApnsConnection {
             int port, Proxy proxy, ReconnectPolicy reconnectPolicy,
             ApnsDelegate delegate) {
         this(factory, host, port, proxy, reconnectPolicy,
-                delegate, false, ApnsConnection.DEFAULT_CACHE_LENGTH, true);
+                delegate, false, ApnsConnection.DEFAULT_CACHE_LENGTH, true, 0);
     }
 
     public ApnsConnectionImpl(SocketFactory factory, String host,
             int port, Proxy proxy,
             ReconnectPolicy reconnectPolicy, ApnsDelegate delegate,
-            boolean errorDetection, int cacheLength, boolean autoAdjustCacheLength) {
+            boolean errorDetection, int cacheLength, boolean autoAdjustCacheLength, int readTimeout) {
         this.factory = factory;
         this.host = host;
         this.port = port;
@@ -99,6 +100,7 @@ public class ApnsConnectionImpl implements ApnsConnection {
         this.errorDetection = errorDetection;
         this.cacheLength = cacheLength;
         this.autoAdjustCacheLength = autoAdjustCacheLength;
+        this.readTimeout = readTimeout;
         cachedNotifications = new ConcurrentLinkedQueue<ApnsNotification>();
         notificationsBuffer = new ConcurrentLinkedQueue<ApnsNotification>();
     }
@@ -217,7 +219,10 @@ public class ApnsConnectionImpl implements ApnsConnection {
                         }
                     }
                 }
-
+                
+                socket.setSoTimeout(readTimeout);
+                socket.setKeepAlive(true);
+                
                 if (errorDetection) {
                     monitorSocket(socket);
                 }
@@ -292,7 +297,7 @@ public class ApnsConnectionImpl implements ApnsConnection {
 
     public ApnsConnectionImpl copy() {
         return new ApnsConnectionImpl(factory, host, port, proxy, reconnectPolicy.copy(),
-                delegate, errorDetection, cacheLength, autoAdjustCacheLength);
+                delegate, errorDetection, cacheLength, autoAdjustCacheLength, readTimeout);
     }
 
     public void testConnection() throws NetworkIOException {

--- a/src/main/java/com/notnoop/apns/internal/ApnsFeedbackConnection.java
+++ b/src/main/java/com/notnoop/apns/internal/ApnsFeedbackConnection.java
@@ -50,17 +50,24 @@ public class ApnsFeedbackConnection {
     private final String host;
     private final int port;
     private final Proxy proxy;
+    private final int readTimeout;
 
     public ApnsFeedbackConnection(final SocketFactory factory, final String host, final int port) {
         this(factory, host, port, null);
     }
-
+    
     public ApnsFeedbackConnection(final SocketFactory factory, final String host, final int port,
             final Proxy proxy) {
+    	this(factory, host, port, proxy, 0);
+    }
+
+    public ApnsFeedbackConnection(final SocketFactory factory, final String host, final int port,
+            final Proxy proxy, int readTimeout) {
         this.factory = factory;
         this.host = host;
         this.port = port;
         this.proxy = proxy;
+        this.readTimeout = readTimeout;
     }
 
     int DELAY_IN_MS = 1000;
@@ -100,7 +107,8 @@ public class ApnsFeedbackConnection {
                 proxySocket.connect(new InetSocketAddress(host, port));
                 socket = ((SSLSocketFactory) factory).createSocket(proxySocket, host, port, false);
             }
-            
+            socket.setSoTimeout(readTimeout);
+            socket.setKeepAlive(true);
             final InputStream stream = socket.getInputStream();
             return Utilities.parseFeedbackStream(stream);
         } finally {

--- a/src/test/java/com/notnoop/apns/utils/ApnsServerStub.java
+++ b/src/test/java/com/notnoop/apns/utils/ApnsServerStub.java
@@ -19,6 +19,7 @@ public class ApnsServerStub {
         server.start();
         return server;
     }
+    public final AtomicInteger toWaitBeforeSend = new AtomicInteger(0);
     public final ByteArrayOutputStream received;
     public final ByteArrayOutputStream toSend;
     public final Semaphore messages = new Semaphore(0);
@@ -108,6 +109,8 @@ public class ApnsServerStub {
 
                 // Read from in and write to out...
                 byte[] read = readFully(in);
+                
+                waitBeforeSend();
                 received.write(read);
                 messages.release();
 
@@ -155,6 +158,7 @@ public class ApnsServerStub {
                 InputStream in = socket.getInputStream();
                 OutputStream out = socket.getOutputStream();
 
+                waitBeforeSend();
                 // Read from in and write to out...
                 toSend.writeTo(out);
 
@@ -187,4 +191,18 @@ public class ApnsServerStub {
 
         return stream.toByteArray();
     }
+    
+    /**
+     * Introduces a waiting time, used to trigger read timeouts.
+     */
+    private void waitBeforeSend() {
+    	int wait = toWaitBeforeSend.get();
+    	if(wait!=0)
+			try {
+				Thread.sleep(wait);
+			} catch (InterruptedException e) {
+				throw new RuntimeException(e);
+			}
+    }
+    
 }


### PR DESCRIPTION
I have found a weird behavior in one of my servers:

```
"task-scheduler-0" prio=10 tid=0x00007fef2d642800 nid=0x3c5b runnable [0x00007fef007d0000]
   java.lang.Thread.State: RUNNABLE
        at java.net.SocketInputStream.socketRead0(Native Method)
        at java.net.SocketInputStream.read(SocketInputStream.java:150)
        at java.net.SocketInputStream.read(SocketInputStream.java:121)
        at sun.security.ssl.InputRecord.readFully(InputRecord.java:442)
        at sun.security.ssl.InputRecord.read(InputRecord.java:480)
        at sun.security.ssl.SSLSocketImpl.readRecord(SSLSocketImpl.java:927)
        - locked <0x0000000786f6a120> (a java.lang.Object)
        at sun.security.ssl.SSLSocketImpl.performInitialHandshake(SSLSocketImpl.java:1312)
        - locked <0x0000000786f6a0e0> (a java.lang.Object)
        at sun.security.ssl.SSLSocketImpl.readDataRecord(SSLSocketImpl.java:882)
        at sun.security.ssl.AppInputStream.read(AppInputStream.java:102)
        - locked <0x0000000786f722d0> (a sun.security.ssl.AppInputStream)
        at sun.security.ssl.AppInputStream.read(AppInputStream.java:69)
        - locked <0x0000000786f722d0> (a sun.security.ssl.AppInputStream)
        at java.io.DataInputStream.readInt(DataInputStream.java:387)
        at com.notnoop.apns.internal.Utilities.parseFeedbackStreamRaw(Utilities.java:200)
        at com.notnoop.apns.internal.Utilities.parseFeedbackStream(Utilities.java:219)
        at com.notnoop.apns.internal.ApnsFeedbackConnection.getInactiveDevicesImpl(ApnsFeedbackConnection.java:105)
        at com.notnoop.apns.internal.ApnsFeedbackConnection.getInactiveDevices(ApnsFeedbackConnection.java:74)
        at com.notnoop.apns.internal.AbstractApnsService.getInactiveDevices(AbstractApnsService.java:132)
        at com.notnoop.apns.internal.ApnsServiceImpl.getInactiveDevices(ApnsServiceImpl.java:36)
```

This thread is in this state for ages already. I would like to be able to set a read timeout to avoid the ApnsService#getInactiveDevices() call to be locked this long.
