### PR TITLE
Adding content-available:1 for silent messages and instant app wake up

### DIFF
--- a/src/main/java/com/notnoop/apns/PayloadBuilder.java
+++ b/src/main/java/com/notnoop/apns/PayloadBuilder.java
@@ -159,6 +159,19 @@ public final class PayloadBuilder {
     }
 
     /**
+     * With iOS7 it is possible to have the application wake up before the user opens the app.
+     * 
+     * The same key-word can also be used to send 'silent' notifications. With these 'silent' notification 
+     * a different app delegate is being invoked, allowing the app to perform background tasks.
+     *
+     * @return this
+     */
+    public PayloadBuilder instantDeliveryOrSlientNofitication() {
+        root.put("content-available", 1);
+        return this;
+    }
+
+    /**
      * Set the notification localized key for the alert body
      * message.
      *

--- a/src/test/java/com/notnoop/apns/PayloadBuilderTest.java
+++ b/src/test/java/com/notnoop/apns/PayloadBuilderTest.java
@@ -482,4 +482,39 @@ public class PayloadBuilderTest {
 
         assertThat(s1, containsString(str));
     }
+    
+    @Test
+    public void slientPingMessage() {
+        final PayloadBuilder builder = new PayloadBuilder();
+        builder.instantDeliveryOrSlientNofitication();
+
+        final String expected = "{\"aps\":{},\"content-available\":1}";
+        final String actual = builder.toString();
+        assertEqualsJson(expected, actual);
+        
+    }
+
+    @Test
+    public void slientPingMessageWithCustomKey() {
+        final PayloadBuilder builder = new PayloadBuilder();
+        
+        builder.instantDeliveryOrSlientNofitication();
+        builder.customField("ache1", "what");
+
+        final String expected = "{\"aps\":{},\"ache1\":\"what\",\"content-available\":1}";
+        final String actual = builder.toString();
+        assertEqualsJson(expected, actual);
+        
+    }
+
+    @Test
+    public void instantMessageWithAlert() {
+        final PayloadBuilder builder = new PayloadBuilder();
+        builder.alertBody("test");
+        builder.instantDeliveryOrSlientNofitication();
+
+        final String expected = "{\"aps\":{\"alert\":\"test\"},\"content-available\":1}";
+        final String actual = builder.toString();
+        assertEqualsJson(expected, actual);
+    }
 }


### PR DESCRIPTION
For iOS7 notifications can instantly wake up the app and also silent messages are supported.

Feature is discussed here:
https://developer.apple.com/wwdc/videos/index.php?id=204
