### PR TITLE
Add methods to support New Safari Push Notifications

### DIFF
--- a/src/main/java/com/notnoop/apns/PayloadBuilder.java
+++ b/src/main/java/com/notnoop/apns/PayloadBuilder.java
@@ -70,6 +70,44 @@ public final class PayloadBuilder {
     }
 
     /**
+     * Sets the alert title text, the text the appears to the user,
+     * to the passed value
+     *
+     * @param title the text to appear to the user
+     * @return  this
+     */
+    public PayloadBuilder alertTitle(final String title) {
+        customAlert.put("title", title);
+        return this;
+    }
+
+    /**
+     * Sets the alert action text
+     *
+     * @param action The label of the action button
+     * @return  this
+     */
+    public PayloadBuilder alertAction(final String action) {
+        customAlert.put("action", action);
+        return this;
+    }
+
+    /**
+     * Sets the "url-args" key that are paired with the placeholders
+     * inside the urlFormatString value of your website.json file.
+     * The order of the placeholders in the URL format string determines
+     * the order of the values supplied by the url-args array.
+     *
+     * @param urlArgs the values to be paired with the placeholders inside
+     *                the urlFormatString value of your website.json file.
+     * @return  this
+     */
+    public PayloadBuilder urlArgs(final String... urlArgs){
+        aps.put("url-args", urlArgs);
+        return this;
+    }
+
+    /**
      * Sets the alert sound to be played.
      *
      * Passing {@code null} disables the notification sound.

--- a/src/test/java/com/notnoop/apns/PayloadBuilderTest.java
+++ b/src/test/java/com/notnoop/apns/PayloadBuilderTest.java
@@ -45,6 +45,18 @@ public class PayloadBuilderTest {
     }
 
     @Test
+    public void testSafariAps() {
+        final PayloadBuilder builder = new PayloadBuilder();
+        builder.alertBody("test");
+        builder.alertTitle("Test Title");
+        builder.actionKey("View");
+        builder.urlArgs("arg1", "arg2", "arg3");
+
+        final String expected = "{\"aps\":{\"alert\":{\"body\":\"test\",\"title\":\"Test Title\",\"action-loc-key\":\"View\"},\"url-args\":[\"arg1\",\"arg2\",\"arg3\"]}}";
+        assertEqualsJson(expected, builder.build());
+    }
+
+    @Test
     public void testTwoApsMultipleBuilds() {
         final PayloadBuilder builder = new PayloadBuilder();
         builder.alertBody("test");


### PR DESCRIPTION
The format of the payload for a Safari notification is slightly different.  

```
{
    "aps": {
        "alert": {
            "title": "Flight A998 Now Boarding",
            "body": "Boarding has begun for Flight A998.",
            "action": "View"
        },
        "url-args": ["boarding", "A998"]
   }
}
```

this adds 3 new methods,  

`alertTitle` , `alertAction` , and `urlArgs` 
