### PR TITLE
Fixed bug: Missed notifications after gate error response

### DIFF
--- a/src/main/java/com/notnoop/apns/internal/ApnsConnectionImpl.java
+++ b/src/main/java/com/notnoop/apns/internal/ApnsConnectionImpl.java
@@ -202,11 +202,9 @@ public class ApnsConnectionImpl implements ApnsConnection {
                     close();
                 }
 
-                if (validNotifications.size() > 0) {
-                    for (ApnsNotification notification : validNotifications) {
-                        logger.debug("Resend notification id={}", notification.getIdentifier());
-                        sendMessage(notification, true);
-                    }
+                for (ApnsNotification notification : validNotifications) {
+                    logger.debug("Resend notification id={}", notification.getIdentifier());
+                    sendMessage(notification, true);
                 }
             }
 


### PR DESCRIPTION
After first error packet receiving  socket was recreated and valid notifications from cache were lost.
Also it was possible bug with StackOverflowException with recursive queue draining.
