### PR TITLE
Fix for Bug #186

### DIFF
--- a/src/main/java/com/notnoop/apns/internal/TlsTunnelBuilder.java
+++ b/src/main/java/com/notnoop/apns/internal/TlsTunnelBuilder.java
@@ -91,10 +91,8 @@ public final class TlsTunnelBuilder {
             ProxyClient client = new ProxyClient();
             client.getParams().setParameter("http.useragent", "java-apns");
             client.getHostConfiguration().setHost(host, port);
-            String proxyHost = proxyAddress.getAddress().toString().substring(0, proxyAddress.getAddress().toString().indexOf("/"));
-            client.getHostConfiguration().setProxy(proxyHost, proxyAddress.getPort());
+            client.getHostConfiguration().setProxy(proxyAddress.getHostString(), proxyAddress.getPort());
             
-        
             ProxyClient.ConnectResponse response = client.connect();
             socket = response.getSocket();
             if (socket == null) {
@@ -103,7 +101,8 @@ public final class TlsTunnelBuilder {
                 if(method.getStatusLine().toString().matches("HTTP/1\\.\\d 407 Proxy Authentication Required")) {
                     // Proxy server returned 407. We will now try to connect with auth Header
                     if(proxyUsername != null && proxyPassword != null) {
-                        socket = AuthenticateProxy(method, client,proxyHost, proxyAddress.getPort(),
+                        socket = AuthenticateProxy(method, client,
+                                proxyAddress.getHostString(), proxyAddress.getPort(),
                                 proxyUsername, proxyPassword);
                     } else {
                         throw new ProtocolException("Socket not created: " + method.getStatusLine()); 


### PR DESCRIPTION
Proxy support does not work when the IP address of the proxy server is
used instead of the hostname. This issue was introduced when adding
support for authentication proxies.
