### PR TITLE
Added StartSendingApnsDelegate with callback before notification sending

### DIFF
--- a/src/main/java/com/notnoop/apns/StartSendingApnsDelegate.java
+++ b/src/main/java/com/notnoop/apns/StartSendingApnsDelegate.java
@@ -1,0 +1,17 @@
+package com.notnoop.apns;
+
+/**
+ * A delegate that also gets notified just before a notification is being delivered to the
+ * Apple Server.
+ */
+public interface StartSendingApnsDelegate extends ApnsDelegate {
+
+    /**
+     * Called when message is about to be sent to the Apple servers.
+     *
+     * @param message the notification that is about to be sent
+     * @param resent whether the notification is being resent after an error
+     */
+    public void startSending(ApnsNotification message, boolean resent);
+
+}

--- a/src/main/java/com/notnoop/apns/internal/ApnsConnectionImpl.java
+++ b/src/main/java/com/notnoop/apns/internal/ApnsConnectionImpl.java
@@ -46,6 +46,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import javax.net.SocketFactory;
 import javax.net.ssl.SSLSocketFactory;
 import com.notnoop.apns.ApnsDelegate;
+import com.notnoop.apns.StartSendingApnsDelegate;
 import com.notnoop.apns.ApnsNotification;
 import com.notnoop.apns.DeliveryError;
 import com.notnoop.apns.EnhancedApnsNotification;
@@ -314,6 +315,10 @@ public class ApnsConnectionImpl implements ApnsConnection {
 
     private synchronized void sendMessage(ApnsNotification m, boolean fromBuffer) throws NetworkIOException {
         logger.debug("sendMessage {} fromBuffer: {}", m, fromBuffer);
+
+        if (delegate instanceof StartSendingApnsDelegate) {
+            ((StartSendingApnsDelegate) delegate).startSending(m, fromBuffer);
+        }
 
         int attempts = 0;
         while (true) {


### PR DESCRIPTION
Pull request for issue #212 adding a subinterface of ApnsDelegate providing a callback that is invoked just before a notification is being sent for enhanced notification state tracking.

I consciously implemented this as a backwards-compatible change so existing implementations of  ApnsDelegate do not break. A simpler but breaking change would be to add the new callback directly to ApnsDelegate.