### PR TITLE
Support for idleConnection cleanup

### DIFF
--- a/src/main/java/com/notnoop/apns/ApnsServiceBuilder.java
+++ b/src/main/java/com/notnoop/apns/ApnsServiceBuilder.java
@@ -590,8 +590,9 @@ public class ApnsServiceBuilder {
     }
 
     /**
-     * Closes connections that are idle for the given idle connection timeout
-     *
+     * Closes / invalidates connections that are idle for the given idle connection timeout
+     * in milliseconds
+     * 
      * @return  this
      */
     public ApnsServiceBuilder withIdleConnectionTimeout(int idleConnectionTimeout) {

--- a/src/main/java/com/notnoop/apns/ApnsServiceBuilder.java
+++ b/src/main/java/com/notnoop/apns/ApnsServiceBuilder.java
@@ -103,6 +103,8 @@ public class ApnsServiceBuilder {
     private boolean errorDetection = true;
     private ThreadFactory errorDetectionThreadFactory = null;
 
+    private int connectionIdleTimeout = 0;
+    
     /**
      * Constructs a new instance of {@code ApnsServiceBuilder}
      */
@@ -588,6 +590,16 @@ public class ApnsServiceBuilder {
     }
 
     /**
+     * Closes connections that are idle for the given idle connection timeout
+     *
+     * @return  this
+     */
+    public ApnsServiceBuilder withIdleConnectionTimeout(int idleConnectionTimeout) {
+        this.connectionIdleTimeout = idleConnectionTimeout;
+        return this;
+    }
+    
+    /**
      * Provide a custom source for threads used for monitoring connections.
      *
      * This setting is desired when the application must obtain threads from a
@@ -617,7 +629,7 @@ public class ApnsServiceBuilder {
         ApnsConnection conn = new ApnsConnectionImpl(sslFactory, gatewayHost,
             gatewayPort, proxy, proxyUsername, proxyPassword, reconnectPolicy,
                 delegate, errorDetection, errorDetectionThreadFactory, cacheLength,
-                autoAdjustCacheLength, readTimeout, connectTimeout);
+                autoAdjustCacheLength, readTimeout, connectTimeout, connectionIdleTimeout);
         if (pooledMax != 1) {
             conn = new ApnsPooledConnection(conn, pooledMax, executor);
         }

--- a/src/main/java/com/notnoop/apns/internal/ApnsConnectionImpl.java
+++ b/src/main/java/com/notnoop/apns/internal/ApnsConnectionImpl.java
@@ -412,7 +412,7 @@ public class ApnsConnectionImpl implements ApnsConnection {
     
     private class IdleConnectionCleanupTask implements Runnable {
     
-        	public void run() {
+         public void run() {
              long idleTimeInMillis = System.currentTimeMillis() - idleSince;
              int connectionIdleTimeoutInMillis = connectionIdleTimeout * 1000; 
              logger.debug("IdleConnectionCleanupTask", "APNS Connection Idle For (in seconds) : " + idleTimeInMillis / 1000);


### PR DESCRIPTION
Issue #214

The ability to cleanup idle connections is missing. This leads to sockets not being closed even if they are closed by mid-parties like proxies / firewalls. This leads to missing notifications when notifications are submitted on the stale sockets. Tried to fix this by a new property called "idleConnectionTimeout" after which the connections are closed so that the subsequent requests are submitted on a new connection. 