### PR TITLE
Added provided scope for findbugs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -245,6 +245,7 @@
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>annotations</artifactId>
             <version>2.0.3</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
FindBugs is for static analysis of Java code, so it is unnecessary to include the findbugs annotations jar for runtime.