### PR TITLE
Clients cannot tell whether a message send failed call is for a resend or first send of a message

### DIFF
--- a/src/main/java/com/notnoop/apns/internal/ApnsConnectionImpl.java
+++ b/src/main/java/com/notnoop/apns/internal/ApnsConnectionImpl.java
@@ -254,7 +254,7 @@ public class ApnsConnectionImpl implements ApnsConnection {
         t.start();
     }
 
-    private synchronized Socket getOrCreateSocket() throws NetworkIOException {
+    private synchronized Socket getOrCreateSocket(boolean resend) throws NetworkIOException {
         if (reconnectPolicy.shouldReconnect()) {
             logger.debug("Reconnecting due to reconnectPolicy dictating it");
             Utilities.close(socket);
@@ -297,7 +297,7 @@ public class ApnsConnectionImpl implements ApnsConnection {
                 logger.debug("Made a new connection to APNS");
             } catch (IOException e) {
                 logger.error("Couldn't connect to APNS server", e);
-                throw new NetworkIOException(e);
+                throw new NetworkIOException(e, resend);
             }
         }
         return socket;
@@ -318,7 +318,7 @@ public class ApnsConnectionImpl implements ApnsConnection {
         while (true) {
             try {
                 attempts++;
-                Socket socket = getOrCreateSocket();
+                Socket socket = getOrCreateSocket(fromBuffer);
                 socket.getOutputStream().write(m.marshall());
                 socket.getOutputStream().flush();
                 cacheNotification(m);

--- a/src/main/java/com/notnoop/exceptions/NetworkIOException.java
+++ b/src/main/java/com/notnoop/exceptions/NetworkIOException.java
@@ -41,9 +41,30 @@ import java.io.IOException;
 public class NetworkIOException extends ApnsException {
     private static final long serialVersionUID = 3353516625486306533L;
 
+    private boolean resend;
+
     public NetworkIOException()                      { super(); }
     public NetworkIOException(String message)        { super(message); }
     public NetworkIOException(IOException cause)       { super(cause); }
     public NetworkIOException(String m, IOException c) { super(m, c); }
+    public NetworkIOException(IOException cause, boolean resend) {
+        super(cause);
+        this.resend = resend;
+    }
+
+    /**
+     * Identifies whether an exception was thrown during a resend of a
+     * message or not.  In this case a resend refers to whether the
+     * message is being resent from the buffer of messages internal.
+     * This would occur if we sent 5 messages quickly to APNS:
+     * 1,2,3,4,5 and the 3 message was rejected.  We would
+     * then need to resend 4 and 5.  If a network exception was
+     * triggered when doing this, then the resend flag will be
+     * {@code true}.
+     * @return {@code true} for an exception trigger during a resend, otherwise {@code false}.
+     */
+    public boolean isResend() {
+        return resend;
+    }
 
 }


### PR DESCRIPTION
We wish to use your library for our application but we need to take specific action if the library fails to resubmit a message.  We need to be able to differentiate between ApnsDelegate.messageSendFailed calls that are from trying to resend messages from the internal buffer or from the original sending of a message.

Example

1.  Send messages 1,2,3,4
2.  Message 2 is rejected by APNS because of an invalid token.
3.  Java-Apns tries to resend 3,4 as per ApnsConnectionImpl.monitorSocket
4.  The network for the server has died and APNS cannot be contacted.

We modified NetworkIOException to return whether the exception was thrown during a first send or resend from the buffer.  With this modification we can make provision for the messages to be retried later.  Without these changes it is impossible for us to differentiate these specific circumstances.

As these changes do not change the API for ApnsDelegate we are hoping you will be able to accept them.