### PR TITLE
Support informing a client of when a message send failed because of a resend

### DIFF
--- a/src/main/java/com/notnoop/apns/internal/ApnsConnectionImpl.java
+++ b/src/main/java/com/notnoop/apns/internal/ApnsConnectionImpl.java
@@ -254,7 +254,7 @@ public class ApnsConnectionImpl implements ApnsConnection {
         t.start();
     }
 
-    private synchronized Socket getOrCreateSocket() throws NetworkIOException {
+    private synchronized Socket getOrCreateSocket(boolean resend) throws NetworkIOException {
         if (reconnectPolicy.shouldReconnect()) {
             logger.debug("Reconnecting due to reconnectPolicy dictating it");
             Utilities.close(socket);
@@ -297,7 +297,7 @@ public class ApnsConnectionImpl implements ApnsConnection {
                 logger.debug("Made a new connection to APNS");
             } catch (IOException e) {
                 logger.error("Couldn't connect to APNS server", e);
-                throw new NetworkIOException(e);
+                throw new NetworkIOException(e, resend);
             }
         }
         return socket;
@@ -318,7 +318,7 @@ public class ApnsConnectionImpl implements ApnsConnection {
         while (true) {
             try {
                 attempts++;
-                Socket socket = getOrCreateSocket();
+                Socket socket = getOrCreateSocket(fromBuffer);
                 socket.getOutputStream().write(m.marshall());
                 socket.getOutputStream().flush();
                 cacheNotification(m);

--- a/src/main/java/com/notnoop/exceptions/NetworkIOException.java
+++ b/src/main/java/com/notnoop/exceptions/NetworkIOException.java
@@ -41,9 +41,30 @@ import java.io.IOException;
 public class NetworkIOException extends ApnsException {
     private static final long serialVersionUID = 3353516625486306533L;
 
+    private boolean resend;
+
     public NetworkIOException()                      { super(); }
     public NetworkIOException(String message)        { super(message); }
     public NetworkIOException(IOException cause)       { super(cause); }
     public NetworkIOException(String m, IOException c) { super(m, c); }
+    public NetworkIOException(IOException cause, boolean resend) {
+        super(cause);
+        this.resend = resend;
+    }
+
+    /**
+     * Identifies whether an exception was thrown during a resend of a
+     * message or not.  In this case a resend refers to whether the
+     * message is being resent from the buffer of messages internal.
+     * This would occur if we sent 5 messages quickly to APNS:
+     * 1,2,3,4,5 and the 3 message was rejected.  We would
+     * then need to resend 4 and 5.  If a network exception was
+     * triggered when doing this, then the resend flag will be
+     * {@code true}.
+     * @return {@code true} for an exception trigger during a resend, otherwise {@code false}.
+     */
+    public boolean isResend() {
+        return resend;
+    }
 
 }

--- a/src/test/java/com/notnoop/apns/integration/ApnsConnectionResendTest.java
+++ b/src/test/java/com/notnoop/apns/integration/ApnsConnectionResendTest.java
@@ -1,0 +1,111 @@
+package com.notnoop.apns.integration;
+
+import com.notnoop.apns.APNS;
+import com.notnoop.apns.ApnsDelegate;
+import com.notnoop.apns.ApnsNotification;
+import com.notnoop.apns.ApnsService;
+import com.notnoop.apns.DeliveryError;
+import com.notnoop.apns.EnhancedApnsNotification;
+import com.notnoop.apns.integration.ApnsDelegateRecorder.MessageSentFailedRecord;
+import com.notnoop.apns.utils.FixedCertificates;
+import com.notnoop.apns.utils.Simulator.ApnsResponse;
+import com.notnoop.apns.utils.Simulator.ApnsSimulatorWithVerification;
+import com.notnoop.exceptions.ApnsDeliveryErrorException;
+import com.notnoop.exceptions.NetworkIOException;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static com.notnoop.apns.utils.FixedCertificates.LOCALHOST;
+import static com.notnoop.apns.utils.FixedCertificates.clientContext;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ApnsConnectionResendTest {
+
+    private static EnhancedApnsNotification NOTIFICATION_0 = buildNotification(0);
+    private static EnhancedApnsNotification NOTIFICATION_1 = buildNotification(1);
+    private static EnhancedApnsNotification NOTIFICATION_2 = buildNotification(2);
+    private static ApnsSimulatorWithVerification apnsSim;
+
+    private ApnsDelegateRecorder delegateRecorder;
+    private ApnsService testee;
+
+    @Before
+    public void setUp() {
+        if (apnsSim == null) {
+            apnsSim = new ApnsSimulatorWithVerification(FixedCertificates.serverContext().getServerSocketFactory());
+            apnsSim.start();
+        }
+        apnsSim.reset();
+        delegateRecorder = new ApnsDelegateRecorder();
+        testee = build(delegateRecorder);
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+        if (apnsSim != null) {
+            apnsSim.stop();
+            apnsSim = null;
+        }
+    }
+
+    /*
+     * Test when we submit 3 messages to APNS 0, 1, 2.  0 is an error but we don't see the error response back until
+     * 1,2 have already been submitted.  Then at this point the network connection to APNS cannot be made, so that
+     * when retrying the submissions we have to notify the client that delivery failed for 1 and 2.
+     */
+    @Test
+    public void testGivenFailedSubmissionDueToErrorThenApnsDownWithNotificationsInBufferEnsureClientNotified()
+            throws Exception {
+
+        final DeliveryError deliveryError = DeliveryError.INVALID_PAYLOAD_SIZE;
+
+        apnsSim.when(NOTIFICATION_0).thenDoNothing();
+        apnsSim.when(NOTIFICATION_1).thenDoNothing();
+        apnsSim.when(NOTIFICATION_2).thenRespond(ApnsResponse.returnErrorAndShutdown(deliveryError, NOTIFICATION_0));
+
+        testee.push(NOTIFICATION_0);
+        testee.push(NOTIFICATION_1);
+        testee.push(NOTIFICATION_2);
+
+        // Give some time for connection failure to take place
+        Thread.sleep(5000);
+        // Verify received expected notifications
+        apnsSim.verify();
+
+        // verify delegate calls
+        assertEquals(3, delegateRecorder.getSent().size());
+        final List<MessageSentFailedRecord> failed = delegateRecorder.getFailed();
+        assertEquals(3, failed.size());
+        // first is failed delivery due to payload size
+        failed.get(0).assertRecord(NOTIFICATION_0, new ApnsDeliveryErrorException(deliveryError));
+        // second and third are due to not being able to connect to APNS
+        assertNetworkIoExForRedelivery(NOTIFICATION_1, failed.get(1));
+        assertNetworkIoExForRedelivery(NOTIFICATION_2, failed.get(2));
+    }
+
+    private void assertNetworkIoExForRedelivery(ApnsNotification notification, MessageSentFailedRecord failed) {
+        failed.assertRecord(notification, new NetworkIOException());
+        final NetworkIOException found = failed.getException();
+        assertTrue(found.isResend());
+    }
+
+
+    private ApnsService build(ApnsDelegate delegate) {
+        return APNS.newService()
+                .withConnectTimeout(1000)
+                .withSSLContext(clientContext())
+                .withGatewayDestination(LOCALHOST, apnsSim.getEffectiveGatewayPort())
+                .withFeedbackDestination(LOCALHOST, apnsSim.getEffectiveFeedbackPort())
+                .withDelegate(delegate).build();
+    }
+
+    private static EnhancedApnsNotification buildNotification(int id) {
+        final String deviceToken = ApnsSimulatorWithVerification.deviceTokenForId(id);
+        return new EnhancedApnsNotification(id, 1, deviceToken, "{\"aps\":{}}");
+    }
+
+}

--- a/src/test/java/com/notnoop/apns/integration/ApnsDelegateRecorder.java
+++ b/src/test/java/com/notnoop/apns/integration/ApnsDelegateRecorder.java
@@ -1,0 +1,93 @@
+package com.notnoop.apns.integration;
+
+import com.notnoop.apns.ApnsDelegate;
+import com.notnoop.apns.ApnsNotification;
+import com.notnoop.apns.DeliveryError;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class ApnsDelegateRecorder implements ApnsDelegate {
+
+    private List<MessageSentRecord> sent = new ArrayList<MessageSentRecord>();
+    private List<MessageSentFailedRecord> failed = new ArrayList<MessageSentFailedRecord>();
+
+    @Override
+    public void messageSent(ApnsNotification message, boolean resent) {
+        sent.add(new MessageSentRecord(message, resent));
+    }
+
+    @Override
+    public void messageSendFailed(ApnsNotification message, Throwable e) {
+        failed.add(new MessageSentFailedRecord(message, e));
+    }
+
+    @Override
+    public void connectionClosed(DeliveryError e, int messageIdentifier) {
+        // not stubbed
+    }
+
+    @Override
+    public void cacheLengthExceeded(int newCacheLength) {
+        // not stubbed
+    }
+
+    @Override
+    public void notificationsResent(int resendCount) {
+        // not stubbed
+    }
+
+    public List<MessageSentRecord> getSent() {
+        return Collections.unmodifiableList(sent);
+    }
+
+    public List<MessageSentFailedRecord> getFailed() {
+        return Collections.unmodifiableList(failed);
+    }
+
+    public static class MessageSentRecord {
+        private final ApnsNotification notification;
+        private final boolean resent;
+
+        public MessageSentRecord(ApnsNotification notification, boolean resent) {
+            this.notification = notification;
+            this.resent = resent;
+        }
+
+        public ApnsNotification getNotification() {
+            return notification;
+        }
+
+        public boolean isResent() {
+            return resent;
+        }
+    }
+
+    public static class MessageSentFailedRecord {
+        private final ApnsNotification notification;
+        private final Throwable ex;
+
+        public MessageSentFailedRecord(ApnsNotification notification, Throwable ex) {
+            this.notification = notification;
+            this.ex = ex;
+        }
+
+        public ApnsNotification getNotification() {
+            return notification;
+        }
+
+        @SuppressWarnings("unchecked")
+        public <T> T getException() {
+            return (T) ex;
+        }
+
+        public void assertRecord(ApnsNotification notification, Throwable ex) {
+            assertEquals(notification, getNotification());
+            assertEquals(ex.getClass(), this.ex.getClass());
+        }
+    }
+
+}

--- a/src/test/java/com/notnoop/apns/utils/Simulator/Action.java
+++ b/src/test/java/com/notnoop/apns/utils/Simulator/Action.java
@@ -1,0 +1,5 @@
+package com.notnoop.apns.utils.Simulator;
+
+public enum Action {
+    DO_NOTHING, RETURN_ERROR, RETURN_ERROR_AND_SHUTDOWN
+}

--- a/src/test/java/com/notnoop/apns/utils/Simulator/ApnsNotificationWithAction.java
+++ b/src/test/java/com/notnoop/apns/utils/Simulator/ApnsNotificationWithAction.java
@@ -1,0 +1,38 @@
+package com.notnoop.apns.utils.Simulator;
+
+import com.notnoop.apns.utils.Simulator.ApnsServerSimulator.Notification;
+
+public class ApnsNotificationWithAction {
+    private final Notification notification;
+    private final ApnsResponse response;
+
+    public ApnsNotificationWithAction(Notification notification) {
+        this(notification, ApnsResponse.doNothing());
+    }
+
+    public ApnsNotificationWithAction(Notification notification, ApnsResponse response) {
+        if (notification == null)
+        {
+            throw new NullPointerException("notification cannot be null");
+        }
+        this.notification = notification;
+        if (response == null)
+        {
+            throw new NullPointerException("response cannot be null");
+        }
+        this.response = response;
+    }
+
+    public Notification getNotification() {
+        return notification;
+    }
+
+    public int getId() {
+        return notification.getIdentifier();
+    }
+
+    public ApnsResponse getResponse() {
+        return response;
+    }
+
+}

--- a/src/test/java/com/notnoop/apns/utils/Simulator/ApnsResponse.java
+++ b/src/test/java/com/notnoop/apns/utils/Simulator/ApnsResponse.java
@@ -1,0 +1,50 @@
+package com.notnoop.apns.utils.Simulator;
+
+import com.notnoop.apns.ApnsNotification;
+import com.notnoop.apns.DeliveryError;
+
+public class ApnsResponse {
+
+    private final Action action;
+    private final DeliveryError error;
+    private final int errorId;
+
+    private ApnsResponse(Action action, DeliveryError error, int errorId) {
+        this.action = action;
+        this.error = error;
+        this.errorId = errorId;
+    }
+
+    public boolean isDoNothing() {
+        return action == Action.DO_NOTHING;
+    }
+
+    public Action getAction() {
+        return action;
+    }
+
+    public DeliveryError getError() {
+        return error;
+    }
+
+    public int getErrorId() {
+        return errorId;
+    }
+
+    public static ApnsResponse doNothing() {
+        return new ApnsResponse(Action.DO_NOTHING, null, 0);
+    }
+
+    public static ApnsResponse returnError(DeliveryError error, int errorId) {
+        return new ApnsResponse(Action.RETURN_ERROR, error, errorId);
+    }
+
+    public static ApnsResponse returnErrorAndShutdown(DeliveryError error, int errorId) {
+        return new ApnsResponse(Action.RETURN_ERROR_AND_SHUTDOWN, error, errorId);
+    }
+
+    public static ApnsResponse returnErrorAndShutdown(DeliveryError error, ApnsNotification notification) {
+        return new ApnsResponse(Action.RETURN_ERROR_AND_SHUTDOWN, error, notification.getIdentifier());
+    }
+
+}

--- a/src/test/java/com/notnoop/apns/utils/Simulator/ApnsServerSimulator.java
+++ b/src/test/java/com/notnoop/apns/utils/Simulator/ApnsServerSimulator.java
@@ -323,8 +323,8 @@ public abstract class ApnsServerSimulator {
             ByteArrayOutputStream os = new ByteArrayOutputStream();
             DataOutputStream dos = new DataOutputStream(os);
             final int unixTime = (int) (new Date().getTime() / 1000);
-            dos.write(unixTime);
-            dos.write((short) token.length);
+            dos.writeInt(unixTime);
+            dos.writeShort((short) token.length);
             dos.write(token);
             dos.close();
             inputOutputSocket.syncWrite(os.toByteArray());

--- a/src/test/java/com/notnoop/apns/utils/Simulator/ApnsSimulatorWithVerification.java
+++ b/src/test/java/com/notnoop/apns/utils/Simulator/ApnsSimulatorWithVerification.java
@@ -1,0 +1,171 @@
+package com.notnoop.apns.utils.Simulator;
+
+import com.google.common.base.Strings;
+import com.notnoop.apns.EnhancedApnsNotification;
+import com.notnoop.apns.internal.Utilities;
+
+import javax.net.ServerSocketFactory;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Provides a simulator that receives connection over TCP as per a real APNS server.  This class allows verification
+ * and prior configuration of responses in a manner similar to a mocking framework.
+ */
+public class ApnsSimulatorWithVerification extends ApnsServerSimulator {
+
+    private List<Notification> receivedNotifications;
+    private Queue<ApnsNotificationWithAction> expectedWithResponses;
+    private List<Notification> unexpected;
+
+    public ApnsSimulatorWithVerification(ServerSocketFactory sslFactory) {
+        super(sslFactory);
+        receivedNotifications = new ArrayList<Notification>();
+        expectedWithResponses = new ConcurrentLinkedQueue<ApnsNotificationWithAction>();
+        unexpected = new ArrayList<Notification>();
+    }
+
+    public void reset() {
+        receivedNotifications.clear();
+        expectedWithResponses.clear();
+        unexpected.clear();
+    }
+
+    public List<Notification> getReceivedNotifications() {
+        return Collections.unmodifiableList(receivedNotifications);
+    }
+
+    private void addExpected(ApnsNotificationWithAction notificationWithAction) {
+        expectedWithResponses.add(notificationWithAction);
+    }
+
+    protected void onNotification(final Notification notification, final InputOutputSocket inOutSocket)
+            throws IOException {
+        receivedNotifications.add(notification);
+        pollExpectedResponses(notification, inOutSocket);
+    }
+
+    protected void pollExpectedResponses(Notification notification, InputOutputSocket inOutSocket) throws IOException {
+        final ApnsNotificationWithAction withAction = expectedWithResponses.poll();
+        if (withAction == null) {
+            unexpected.add(notification);
+        } else if (!matchNotificationWithExpected(withAction, notification)) {
+            unexpected.add(notification);
+        } else {
+            handleNotificationWithAction(withAction, inOutSocket);
+        }
+    }
+
+    protected void handleNotificationWithAction(ApnsNotificationWithAction notificationWithAction,
+                                                InputOutputSocket inOutSocket) throws IOException {
+        final ApnsResponse response = notificationWithAction.getResponse();
+        if (!response.isDoNothing()) {
+            if (response.getAction() == Action.RETURN_ERROR_AND_SHUTDOWN) {
+                // have to stop first before sending out the error
+                stop();
+                sendError(response, inOutSocket);
+            } else {
+                sendError(response, inOutSocket);
+            }
+        }
+    }
+
+    private boolean matchNotificationWithExpected(ApnsNotificationWithAction withAction, Notification found) {
+        if (withAction.getId() != found.getIdentifier()) {
+            return false;
+        }
+        return matchDeviceToken(withAction.getNotification().getDeviceToken(), found.getDeviceToken());
+    }
+
+    private boolean matchDeviceToken(byte[] expected, byte[] found) {
+        return Arrays.equals(expected, found);
+    }
+
+    protected void sendError(ApnsResponse response, InputOutputSocket inOutSocket) throws IOException {
+        final byte status = (byte) response.getError().code();
+        fail(status, response.getErrorId(), inOutSocket);
+    }
+
+    public DoResponse when(Notification notification) {
+        return new DoResponse(notification);
+    }
+
+    public DoResponse when(EnhancedApnsNotification notification) {
+        return new DoResponse(buildNotification(notification));
+    }
+
+    public void verify() {
+        final int size = expectedWithResponses.size();
+        if (size > 0) {
+            final String error = String.format("[%d] Expected notification(s) were not received, first id was: [%d] ",
+                    size, expectedWithResponses.poll().getId());
+            throw new IllegalStateException(error);
+        }
+        verifyUnexpected();
+    }
+
+    public void verifyAndWait(int waitSecs) {
+        verifyUnexpected();
+
+        long timeRemaining = TimeUnit.SECONDS.toMillis(waitSecs);
+        final long sleepForMs = 250;
+        while (!expectedWithResponses.isEmpty() && timeRemaining > 0) {
+            sleep(sleepForMs < timeRemaining ? sleepForMs : timeRemaining);
+            timeRemaining -= sleepForMs;
+        }
+        verify();
+    }
+
+    private void verifyUnexpected() {
+        if (!unexpected.isEmpty()) {
+            final Notification firstUnexpected = this.unexpected.get(0);
+            throw new IllegalStateException(String.format("Unexpected notifications received, count: [%d].  First" +
+                            " notification is for id: [%d], deviceToken: [%s]", unexpected.size(),
+                    firstUnexpected.getIdentifier(), Utilities.encodeHex(firstUnexpected.getDeviceToken())));
+        }
+    }
+
+    private void sleep(long ms) {
+        try {
+            Thread.sleep(ms);
+        } catch (InterruptedException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    public Notification buildNotification(EnhancedApnsNotification notification) {
+        return new Notification(1, notification.getIdentifier(), notification.getExpiry(),
+                notification.getDeviceToken(), notification.getPayload());
+    }
+
+    public class DoResponse {
+        private final Notification expected;
+
+        public DoResponse(Notification notification) {
+            this.expected = notification;
+        }
+
+        public ApnsSimulatorWithVerification thenRespond(ApnsResponse response) {
+            addExpected(new ApnsNotificationWithAction(expected, response));
+            return ApnsSimulatorWithVerification.this;
+        }
+
+        public ApnsSimulatorWithVerification thenDoNothing() {
+            addExpected(new ApnsNotificationWithAction(expected, ApnsResponse.doNothing()));
+            return ApnsSimulatorWithVerification.this;
+        }
+    }
+
+    public static String deviceTokenForId(int id)
+    {
+        final String right = Integer.toHexString(id).toUpperCase();
+        final int zeroedLength = 64 - right.length();
+        return Strings.repeat("0", zeroedLength) + right;
+    }
+}


### PR DESCRIPTION
There are 4 aspects to the commit:

1.  Set a parameter on the NetworkIOException so that we can identify whether a Delegate.messageSendFailed relates to a resend attempt or not.
2.  Fix the resend code so that it handles the situation where:
We submit 1,2,3,4.  Message 2 is returned as an error, when trying to resend 3,4 we cannot make a network connection to APNS because the network is down.  In the old code this case is not handled and the messages would be lost due to the NetworkIO exception.
3.  Fix a problem with the ApnsServerSimulator, where it did not write out the correct bytes on the wire for the feedback service.
4.  Add a ApnsSimulatorWithVerification, which allows configuration through code of the simulator as similar to a mocking framework.