### PR TITLE
Code quality - Strings literals should be placed on the left side when checking for equality

### DIFF
--- a/src/main/java/com/notnoop/apns/internal/TlsTunnelBuilder.java
+++ b/src/main/java/com/notnoop/apns/internal/TlsTunnelBuilder.java
@@ -122,7 +122,7 @@ public final class TlsTunnelBuilder {
     private Socket AuthenticateProxy(ConnectMethod method, ProxyClient client, 
             String proxyHost, int proxyPort, 
             String proxyUsername, String proxyPassword) throws IOException {   
-        if(method.getProxyAuthState().getAuthScheme().getSchemeName().equalsIgnoreCase("ntlm")) {
+        if("ntlm".equalsIgnoreCase(method.getProxyAuthState().getAuthScheme().getSchemeName())) {
             // If Auth scheme is NTLM, set NT credentials with blank host and domain name
             client.getState().setProxyCredentials(new AuthScope(proxyHost, proxyPort), 
                             new NTCredentials(proxyUsername, proxyPassword,"",""));

--- a/src/test/java/com/notnoop/apns/MainClass.java
+++ b/src/test/java/com/notnoop/apns/MainClass.java
@@ -75,7 +75,7 @@ public class MainClass {
         };
 
         final ApnsService svc = APNS.newService()
-                .withAppleDestination(args[0].equals("p"))
+                .withAppleDestination("p".equals(args[0]))
                 .withCert(new FileInputStream(args[1]), args[2])
                 .withDelegate(delegate)
                 .build();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1132 - “Strings literals should be placed on the left side when checking for equality”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1132

Please let me know if you have any questions.

Christian