### PR TITLE
Code quality fix - Exception handlers should preserve the original exception

### DIFF
--- a/src/main/java/com/notnoop/apns/EnhancedApnsNotification.java
+++ b/src/main/java/com/notnoop/apns/EnhancedApnsNotification.java
@@ -34,12 +34,16 @@ import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;
 import com.notnoop.apns.internal.Utilities;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.io.UnsupportedEncodingException;
 
 /**
  * Represents an APNS notification to be sent to Apple service.
  */
 public class EnhancedApnsNotification implements ApnsNotification {
-
+	
+    private static final Logger LOGGER = LoggerFactory.getLogger(EnhancedApnsNotification.class);
     private final static byte COMMAND = 1;
     private static AtomicInteger nextId = new AtomicInteger(0);
     private final int identifier;
@@ -168,7 +172,8 @@ public class EnhancedApnsNotification implements ApnsNotification {
         String payloadString;
         try {
             payloadString = new String(payload, "UTF-8");
-        } catch (Exception ex) {
+        } catch (UnsupportedEncodingException ex) {
+            LOGGER.debug("UTF-8 charset not found on the JRE", ex);
             payloadString = "???";
         }
         return "Message(Id="+identifier+"; Token="+Utilities.encodeHex(deviceToken)+"; Payload="+payloadString+")";

--- a/src/main/java/com/notnoop/apns/SimpleApnsNotification.java
+++ b/src/main/java/com/notnoop/apns/SimpleApnsNotification.java
@@ -34,7 +34,9 @@ import java.util.Arrays;
 
 import com.notnoop.apns.internal.Utilities;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.io.UnsupportedEncodingException;
 
 /**
  * Represents an APNS notification to be sent to Apple service. This is for legacy use only
@@ -52,7 +54,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 @SuppressWarnings("deprecation")
 @Deprecated
 public class SimpleApnsNotification implements ApnsNotification {
-
+	
+    private static final Logger LOGGER = LoggerFactory.getLogger(SimpleApnsNotification.class);
     private final static byte COMMAND = 0;
     private final byte[] deviceToken;
     private final byte[] payload;
@@ -155,7 +158,8 @@ public class SimpleApnsNotification implements ApnsNotification {
         String payloadString;
         try {
             payloadString = new String(payload, "UTF-8");
-        } catch (Exception ex) {
+        } catch (UnsupportedEncodingException ex) {
+            LOGGER.debug("UTF-8 charset not found on the JRE", ex);
             payloadString = "???";
         }
         return "Message(Token="+Utilities.encodeHex(deviceToken)+"; Payload="+payloadString+")";

--- a/src/main/java/com/notnoop/apns/internal/ApnsConnectionImpl.java
+++ b/src/main/java/com/notnoop/apns/internal/ApnsConnectionImpl.java
@@ -147,6 +147,7 @@ public class ApnsConnectionImpl implements ApnsConnection {
                     try {
                         in = socket.getInputStream();
                     } catch (IOException ioe) {
+                        logger.warn("The value of socket is null", ioe);
                         in = null;
                     }
 

--- a/src/test/java/com/notnoop/apns/utils/ApnsServerStub.java
+++ b/src/test/java/com/notnoop/apns/utils/ApnsServerStub.java
@@ -41,6 +41,8 @@ import java.net.SocketException;
 import java.nio.ByteBuffer;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ApnsServerStub {
 
@@ -70,7 +72,8 @@ public class ApnsServerStub {
         server.start();
         return server;
     }
-
+    
+    private static final Logger LOGGER = LoggerFactory.getLogger(ApnsServerStub.class);
     private final AtomicInteger toWaitBeforeSend = new AtomicInteger(0);
     private final ByteArrayOutputStream received;
     private final ByteArrayOutputStream toSend;
@@ -118,14 +121,14 @@ public class ApnsServerStub {
                 gatewaySocket.close();
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            LOGGER.warn("Can not close gatewaySocket properly", e);
         }
         try {
             if (feedbackSocket != null) {
                 feedbackSocket.close();
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            LOGGER.warn("Can not close feedbackSocket properly", e);
         }
 
         if (gatewayThread != null) {
@@ -146,7 +149,7 @@ public class ApnsServerStub {
             gatewayOutputStream.write(buf.array());
             gatewayOutputStream.flush();
         } catch (Exception ex) {
-            ex.printStackTrace();
+            LOGGER.warn("An error occured with accessing gateway", ex);
         }
     }
 
@@ -227,14 +230,14 @@ public class ApnsServerStub {
                         in.close();
                     }
                 } catch (IOException ioex) {
-                    System.err.println(ioex.toString());
+                    LOGGER.warn("Can not close socket properly", ioex);
                 }
                 try {
                     if (gatewayOutputStream != null) {
                         gatewayOutputStream.close();
                     }
                 } catch (IOException ioex) {
-                    System.err.println(ioex.toString());
+                    LOGGER.warn("Can not close gatewayOutputStream properly", ioex);
                 }
                 messages.release();
             }

--- a/src/test/java/com/notnoop/apns/utils/Simulator/ApnsServerSimulator.java
+++ b/src/test/java/com/notnoop/apns/utils/Simulator/ApnsServerSimulator.java
@@ -85,14 +85,14 @@ public abstract class ApnsServerSimulator {
                 gatewaySocket.close();
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            logger.warn("Can not close gatewaySocket properly", e);
         }
         try {
             if (feedbackSocket != null) {
                 feedbackSocket.close();
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            logger.warn("Can not close feedbackSocket properly", e);
         }
 
         if (gatewayThread != null) {
@@ -141,9 +141,10 @@ public abstract class ApnsServerSimulator {
                     try {
                         handleGatewayConnection(new InputOutputSocket(gatewaySocket.accept()));
                     } catch (SocketException ex) {
+                        logger.warn("Interruption while handling gateway connection", ex);
                         interrupt();
                     } catch (IOException ioe) {
-                        ioe.printStackTrace();
+                        logger.warn("An error occured while handling gateway connection", ioe);
                     }
                 }
             } finally {
@@ -186,6 +187,7 @@ public abstract class ApnsServerSimulator {
                             break;
                     }
                 } catch (IOException ioe) {
+                	logger.warn("An error occured while reading notification", ioe);
                     Thread.currentThread().interrupt();
                 }
             }
@@ -255,7 +257,7 @@ public abstract class ApnsServerSimulator {
             try {
                 gatewaySocket.close();
             } catch (IOException e) {
-                e.printStackTrace();
+                logger.warn("Can not close gatewaySocket properly", e);
             }
         }
     }
@@ -310,9 +312,10 @@ public abstract class ApnsServerSimulator {
                     try {
                         handleFeedbackConnection(new InputOutputSocket(feedbackSocket.accept()));
                     } catch (SocketException ex) {
+                        logger.warn("Interruption while handling feedback connection", ex);
                         interrupt();
                     } catch (IOException ioe) {
-                        ioe.printStackTrace();
+                        logger.warn("An error occured while handling feedback connection", ioe);
                     }
                 }
             } finally {
@@ -331,7 +334,7 @@ public abstract class ApnsServerSimulator {
                         sendFeedback(inputOutputSocket);
                     } catch (IOException ioe) {
                         // An exception is unexpected here. Close the current connection and bail out.
-                        ioe.printStackTrace();
+                        logger.warn("An error occured while sending feedback", ioe);
                     } finally {
                         inputOutputSocket.close();
                     }

--- a/src/test/java/com/notnoop/apns/utils/Simulator/InputOutputSocket.java
+++ b/src/test/java/com/notnoop/apns/utils/Simulator/InputOutputSocket.java
@@ -33,11 +33,14 @@ package com.notnoop.apns.utils.Simulator;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.net.Socket;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Wrap some of the boilerplate code using socket, enable passing around a socket together with its streams.
  */
 public class InputOutputSocket {
+    private static final Logger LOGGER = LoggerFactory.getLogger(InputOutputSocket.class);
     private final Socket socket;
     private final ApnsInputStream inputStream;
     private final DataOutputStream outputStream;
@@ -75,19 +78,19 @@ public class InputOutputSocket {
         try {
             inputStream.close();
         } catch (IOException e) {
-            e.printStackTrace();
+            LOGGER.warn("Can not close inputStream properly", e);
         }
 
         try {
             outputStream.close();
         } catch (IOException e) {
-            e.printStackTrace();
+            LOGGER.warn("Can not close outputStream properly", e);
         }
 
         try {
             socket.close();
         } catch (IOException e) {
-            e.printStackTrace();
+            LOGGER.warn("Can not close socket properly", e);
         }
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1166 - “Exception handlers should preserve the original exception”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1166

Please let me know if you have any questions. 

Christian