### PR TITLE
Using a faster version of getBytes. 

### DIFF
--- a/src/main/java/com/notnoop/apns/internal/Utilities.java
+++ b/src/main/java/com/notnoop/apns/internal/Utilities.java
@@ -38,6 +38,7 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.net.Socket;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
@@ -110,11 +111,7 @@ public final class Utilities {
     }
 
     public static byte[] toUTF8Bytes(final String s) {
-        try {
-            return s.getBytes("UTF-8");
-        } catch (final UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
-        }
+        return s.getBytes(StandardCharsets.UTF_8);
     }
 
     public static byte[] marshall(final byte command, final byte[] deviceToken, final byte[] payload) {

--- a/src/test/java/com/notnoop/apns/internal/TlsTunnelBuilderTest.java
+++ b/src/test/java/com/notnoop/apns/internal/TlsTunnelBuilderTest.java
@@ -33,6 +33,7 @@ package com.notnoop.apns.internal;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 //import java.net.InetSocketAddress;
 //import java.net.Proxy;
 //import java.net.Socket;
@@ -72,6 +73,6 @@ public class TlsTunnelBuilderTest {
     }
 
     private InputStream inputStream(String content) throws IOException {
-        return new ByteArrayInputStream(content.getBytes("UTF-8"));
+        return new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
     }
 }


### PR DESCRIPTION
I had noticed that the payload shortening was very slow. This cuts down the time for this op by half. Please refer https://blog.codecentric.de/en/2014/04/faster-cleaner-code-since-java-7/