### PR TITLE
Fix that allows to use HTTP proxy's IP address

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.notnoop.apns</groupId>
     <artifactId>apns</artifactId>
@@ -66,7 +67,7 @@
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>2.4</version>
                 <configuration>
-                    <archive> 
+                    <archive>
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                     </archive>
                 </configuration>
@@ -78,14 +79,14 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>  
+            <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>2.9.1</version>
-		<!--
-                <configuration>
-                    <additionalparam>-Xdoclint:none</additionalparam>
-                </configuration>
-		-->
+                <!--
+                        <configuration>
+                            <additionalparam>-Xdoclint:none</additionalparam>
+                        </configuration>
+                -->
                 <executions>
                     <execution>
                         <id>generate-javadoc</id>
@@ -125,9 +126,9 @@
                     <execution>
                         <id>bundle-manifest</id>
                         <phase>process-classes</phase>
-                        <goals>   
+                        <goals>
                             <goal>manifest</goal>
-                        </goals>  
+                        </goals>
                     </execution>
                 </executions>
                 <configuration>
@@ -270,6 +271,13 @@
             <artifactId>slf4j-test</artifactId>
             <version>1.0.0-jdk6</version>
             <scope>test</scope>
+
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -290,6 +298,14 @@
             <artifactId>junit</artifactId>
             <version>4.11</version>
             <type>jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- mockserver -->
+        <dependency>
+            <groupId>org.mock-server</groupId>
+            <artifactId>mockserver-netty</artifactId>
+            <version>3.10.1</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/com/notnoop/apns/internal/TlsTunnelBuilder.java
+++ b/src/main/java/com/notnoop/apns/internal/TlsTunnelBuilder.java
@@ -30,20 +30,16 @@
  */
 package com.notnoop.apns.internal;
 
-import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.net.ProtocolException;
-import java.net.Proxy;
-import java.net.Socket;
-import javax.net.ssl.SSLSocketFactory;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import org.apache.commons.httpclient.ConnectMethod;
-import org.apache.commons.httpclient.NTCredentials;
-import org.apache.commons.httpclient.ProxyClient;
-import org.apache.commons.httpclient.UsernamePasswordCredentials;
+import org.apache.commons.httpclient.*;
 import org.apache.commons.httpclient.auth.AuthScope;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.SSLSocketFactory;
+import java.io.IOException;
+import java.net.*;
+import java.net.ProtocolException;
 
 /**
  * Establishes a TLS connection using an HTTP proxy. See <a
@@ -51,9 +47,9 @@ import org.slf4j.LoggerFactory;
  * not support proxies requiring a "Proxy-Authorization" header.
  */
 public final class TlsTunnelBuilder {
-    
+
     private static final Logger logger = LoggerFactory.getLogger(TlsTunnelBuilder.class);
-    
+
     public Socket build(SSLSocketFactory factory, Proxy proxy, String proxyUsername, String proxyPassword, String host, int port)
             throws IOException {
         boolean success = false;
@@ -64,7 +60,7 @@ public final class TlsTunnelBuilder {
             proxySocket = makeTunnel(host, port, proxyUsername, proxyPassword, proxyAddress);
 
             // Handshake with the origin server.
-            if(proxySocket ==  null) {
+            if (proxySocket == null) {
                 throw new ProtocolException("Unable to create tunnel through proxy server.");
             }
             Socket socket = factory.createSocket(proxySocket, host, port, true /* auto close */);
@@ -79,69 +75,77 @@ public final class TlsTunnelBuilder {
 
     @SuppressFBWarnings(value = "VA_FORMAT_STRING_USES_NEWLINE",
             justification = "use <CR><LF> as according to RFC, not platform-linefeed")
-    Socket makeTunnel(String host, int port, String proxyUsername, 
-            String proxyPassword, InetSocketAddress proxyAddress) throws IOException {
-        if(host == null || port < 0 || host.isEmpty() || proxyAddress == null){
-            throw new ProtocolException("Incorrect parameters to build tunnel.");   
+    Socket makeTunnel(String host, int port, String proxyUsername,
+                      String proxyPassword, InetSocketAddress proxyAddress) throws IOException {
+        if (host == null || port < 0 || host.isEmpty() || proxyAddress == null) {
+            throw new ProtocolException("Incorrect parameters to build tunnel.");
         }
-        logger.debug("Creating socket for Proxy : " + proxyAddress.getAddress() + ":" + proxyAddress.getPort());
+        final InetAddress proxyInetAddress = proxyAddress.getAddress();
+        logger.debug("Creating socket for Proxy : " + proxyInetAddress + ":" + proxyAddress.getPort());
         Socket socket;
         try {
             ProxyClient client = new ProxyClient();
             client.getParams().setParameter("http.useragent", "java-apns");
             client.getHostConfiguration().setHost(host, port);
-            String proxyHost = proxyAddress.getAddress().toString().substring(0, proxyAddress.getAddress().toString().indexOf("/"));
+            String proxyHost = proxyInetAddress.getHostName();
             client.getHostConfiguration().setProxy(proxyHost, proxyAddress.getPort());
-            
-        
+
+
             ProxyClient.ConnectResponse response = client.connect();
             socket = response.getSocket();
             if (socket == null) {
                 ConnectMethod method = response.getConnectMethod();
                 // Read the proxy's HTTP response.
-                if(method.getStatusLine().getStatusCode() == 407) {
+                final StatusLine statusLine = method.getStatusLine();
+                int statusCode = statusLine.getStatusCode();
+                if (statusCode == 407) {
                     // Proxy server returned 407. We will now try to connect with auth Header
-                    if(proxyUsername != null && proxyPassword != null) {
-                        socket = AuthenticateProxy(method, client,proxyHost, proxyAddress.getPort(),
+                    if (proxyUsername != null && proxyPassword != null) {
+                        socket = AuthenticateProxy(method, client, proxyHost, proxyAddress.getPort(),
                                 proxyUsername, proxyPassword);
                     } else {
-                        throw new ProtocolException("Socket not created: " + method.getStatusLine()); 
+                        throw new ProtocolException("Socket not created: " + statusLine);
                     }
-                }             
+                } else {
+                    logger.error("Received bad status from proxy server: " + statusLine);
+                }
             }
-            
+
         } catch (Exception e) {
             throw new ProtocolException("Error occurred while creating proxy socket : " + e.toString());
         }
         if (socket != null) {
             logger.debug("Socket for proxy created successfully : " + socket.getRemoteSocketAddress().toString());
+        } else {
+            logger.error("Socket for proxy wasn't created");
         }
+
         return socket;
     }
-    
-    private Socket AuthenticateProxy(ConnectMethod method, ProxyClient client, 
-            String proxyHost, int proxyPort, 
-            String proxyUsername, String proxyPassword) throws IOException {   
-        if("ntlm".equalsIgnoreCase(method.getProxyAuthState().getAuthScheme().getSchemeName())) {
+
+    private Socket AuthenticateProxy(ConnectMethod method, ProxyClient client,
+                                     String proxyHost, int proxyPort,
+                                     String proxyUsername, String proxyPassword) throws IOException {
+        if ("ntlm".equalsIgnoreCase(method.getProxyAuthState().getAuthScheme().getSchemeName())) {
             // If Auth scheme is NTLM, set NT credentials with blank host and domain name
-            client.getState().setProxyCredentials(new AuthScope(proxyHost, proxyPort), 
-                            new NTCredentials(proxyUsername, proxyPassword,"",""));
+            client.getState().setProxyCredentials(new AuthScope(proxyHost, proxyPort),
+                    new NTCredentials(proxyUsername, proxyPassword, "", ""));
         } else {
             // If Auth scheme is Basic/Digest, set regular Credentials
-            client.getState().setProxyCredentials(new AuthScope(proxyHost, proxyPort), 
+            client.getState().setProxyCredentials(new AuthScope(proxyHost, proxyPort),
                     new UsernamePasswordCredentials(proxyUsername, proxyPassword));
         }
-        
+
         ProxyClient.ConnectResponse response = client.connect();
         Socket socket = response.getSocket();
-        
+
         if (socket == null) {
             method = response.getConnectMethod();
-            throw new ProtocolException("Proxy Authentication failed. Socket not created: " 
+            throw new ProtocolException("Proxy Authentication failed. Socket not created: "
                     + method.getStatusLine());
         }
         return socket;
     }
-    
+
 }
 

--- a/src/main/java/com/notnoop/apns/internal/TlsTunnelBuilder.java
+++ b/src/main/java/com/notnoop/apns/internal/TlsTunnelBuilder.java
@@ -87,7 +87,14 @@ public final class TlsTunnelBuilder {
             ProxyClient client = new ProxyClient();
             client.getParams().setParameter("http.useragent", "java-apns");
             client.getHostConfiguration().setHost(host, port);
-            String proxyHost = proxyInetAddress.getHostName();
+
+            /**
+             * There is a bug in an OpenJDK (e.g. https://github.com/travis-ci/travis-ci/issues/5227)
+             * that causes buffer overflow for local addresses. So it would be wise to use host's IP
+             * here since we will still send Host header and will specify target URL in
+             * CONNECT request
+             */
+            String proxyHost = proxyInetAddress.getHostAddress();
             client.getHostConfiguration().setProxy(proxyHost, proxyAddress.getPort());
 
 

--- a/src/test/java/com/notnoop/apns/internal/TlsTunnelBuilderTest.java
+++ b/src/test/java/com/notnoop/apns/internal/TlsTunnelBuilderTest.java
@@ -36,7 +36,6 @@ import org.junit.Test;
 import org.mockserver.integration.ClientAndProxy;
 
 import java.io.IOException;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.net.UnknownHostException;
@@ -49,16 +48,9 @@ public class TlsTunnelBuilderTest {
 
     private static ClientAndProxy mockProxy;
 
-    private static String localhostName;
-    private static String localhostAddress;
-
     @BeforeClass
     public static void beforeClass() throws UnknownHostException {
         mockProxy = startClientAndProxy(MOCK_PROXY_PORT);
-
-        final InetAddress localHost = InetAddress.getLocalHost();
-        localhostAddress = localHost.getHostAddress();
-        localhostName = localHost.getHostName();
     }
 
     @AfterClass
@@ -78,12 +70,17 @@ public class TlsTunnelBuilderTest {
 
     @Test
     public void makeTunnelByHostNameSuccess() {
-        makeTunnelSuccess(localhostName);
+        makeTunnelSuccess("localhost");
     }
 
     @Test
     public void makeTunnelByHostAddressSuccess() {
-        makeTunnelSuccess(localhostAddress);
+        makeTunnelSuccess("127.0.0.1");
+    }
+
+    @Test
+    public void makeTunnelByHostAddressV6Success() {
+        makeTunnelSuccess("::1");
     }
 
     private void makeTunnelSuccess(final String proxyHost) {

--- a/src/test/java/com/notnoop/apns/internal/TlsTunnelBuilderTest.java
+++ b/src/test/java/com/notnoop/apns/internal/TlsTunnelBuilderTest.java
@@ -38,7 +38,6 @@ import org.mockserver.integration.ClientAndProxy;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
-import java.net.UnknownHostException;
 
 import static org.junit.Assert.fail;
 import static org.mockserver.integration.ClientAndProxy.startClientAndProxy;
@@ -49,7 +48,7 @@ public class TlsTunnelBuilderTest {
     private static ClientAndProxy mockProxy;
 
     @BeforeClass
-    public static void beforeClass() throws UnknownHostException {
+    public static void beforeClass() {
         mockProxy = startClientAndProxy(MOCK_PROXY_PORT);
     }
 


### PR DESCRIPTION
During development of our project we've discovered that TLS tunnel wasn't created when we used HTTP proxy server's IP instead of host name. A little digging into a code allowed us to identify the problem. Also I've attached mock proxy server in order to easily run tunneling test in CI.
