### PR TITLE
Fix for vulnerability https://github.com/notnoop/java-apns/issues/286…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -260,9 +260,9 @@
     -->
     <dependencies>
         <dependency>
-            <groupId>commons-httpclient</groupId>
-            <artifactId>commons-httpclient</artifactId>
-            <version>3.1</version>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.1</version>
         </dependency>
 
         <dependency>
@@ -306,6 +306,12 @@
             <version>2.1.4</version>
             <type>jar</type>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.littleshoot</groupId>
+            <artifactId>littleproxy</artifactId>
+            <version>1.1.0-beta1</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
… The old commons httpclient library is exchanged with latest version of apache httpclient which does not have any known security issues. The previous test case has been updated to automatically setup proxy with auth and a basic http server to test the tunnel (it can still be reconfigured to test your local proxy/server combo) The new httpclient does not allow the same way of figuring out which credential protocol is used, but I think that the functionality is basically the same. Implementing the change described in https://github.com/notnoop/java-apns/issues/287 will improve the credentials support further.