### PR TITLE
remove redundant semicolon

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -108,7 +108,7 @@ You can use the enhanced notification format to get feedback from Apple about no
 
      String payload = APNS.newPayload()
                 .badge(3)
-                .customField("secret", "what do you think?");
+                .customField("secret", "what do you think?")
                 .localizedKey("GAME_PLAY_REQUEST_FORMAT")
                 .localizedArguments("Jenna", "Frank")
                 .actionKey("Play").build();


### PR DESCRIPTION
remove redundant semicolon in READMD.md file.

![image](https://cloud.githubusercontent.com/assets/3169221/14344646/7127458a-fcdb-11e5-885e-5f50f1efc983.png)

