### PR TITLE
added getDeliveryErrorDevices() to ApnsService

### DIFF
--- a/src/main/java/com/notnoop/apns/ApnsService.java
+++ b/src/main/java/com/notnoop/apns/ApnsService.java
@@ -33,6 +33,7 @@ package com.notnoop.apns;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Map;
+import java.util.Set;
 
 import com.notnoop.exceptions.NetworkIOException;
 
@@ -160,6 +161,16 @@ public interface ApnsService {
      */
     Map<String, Date> getInactiveDevices() throws NetworkIOException;
 
+    /**
+     * Returns the list of devices got a bad status when tring to send
+     *
+     * The result is map, mapping the device tokens as Hex Strings
+     * mapped to a set of DeliveryError
+     * @throws NetworkIOException if a network error occurred
+     *      while retrieving invalid device connection
+     */
+    Map<String, Set<DeliveryError>> getDeliveryErrorDevices();
+    
     /**
      * Test that the service is setup properly and the Apple servers
      * are reachable.

--- a/src/main/java/com/notnoop/apns/internal/ApnsConnection.java
+++ b/src/main/java/com/notnoop/apns/internal/ApnsConnection.java
@@ -31,8 +31,11 @@
 package com.notnoop.apns.internal;
 
 import java.io.Closeable;
+import java.util.Map;
+import java.util.Set;
 
 import com.notnoop.apns.ApnsNotification;
+import com.notnoop.apns.DeliveryError;
 import com.notnoop.exceptions.NetworkIOException;
 
 public interface ApnsConnection extends Closeable {
@@ -49,4 +52,6 @@ public interface ApnsConnection extends Closeable {
     void setCacheLength(int cacheLength);
     
     int getCacheLength();
+    
+    Map<String, Set<DeliveryError>> getDeliveryErrorDevices();
 }

--- a/src/main/java/com/notnoop/apns/internal/ApnsPooledConnection.java
+++ b/src/main/java/com/notnoop/apns/internal/ApnsPooledConnection.java
@@ -30,8 +30,11 @@
  */
 package com.notnoop.apns.internal;
 
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.*;
 import com.notnoop.apns.ApnsNotification;
+import com.notnoop.apns.DeliveryError;
 import com.notnoop.exceptions.NetworkIOException;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.slf4j.Logger;
@@ -118,4 +121,9 @@ public class ApnsPooledConnection implements ApnsConnection {
     public int getCacheLength() {
         return prototypes.peek().getCacheLength();
     }
+
+	@Override
+	public Map<String, Set<DeliveryError>> getDeliveryErrorDevices() {
+		return prototype.getDeliveryErrorDevices();
+	}
 }

--- a/src/main/java/com/notnoop/apns/internal/ApnsServiceImpl.java
+++ b/src/main/java/com/notnoop/apns/internal/ApnsServiceImpl.java
@@ -30,7 +30,11 @@
  */
 package com.notnoop.apns.internal;
 
+import java.util.Map;
+import java.util.Set;
+
 import com.notnoop.apns.ApnsNotification;
+import com.notnoop.apns.DeliveryError;
 import com.notnoop.exceptions.NetworkIOException;
 
 public class ApnsServiceImpl extends AbstractApnsService {
@@ -56,4 +60,9 @@ public class ApnsServiceImpl extends AbstractApnsService {
     public void testConnection() {
         connection.testConnection();
     }
+
+	@Override
+	public Map<String, Set<DeliveryError>> getDeliveryErrorDevices() {
+		return connection.getDeliveryErrorDevices();
+	}
 }

--- a/src/main/java/com/notnoop/apns/internal/BatchApnsService.java
+++ b/src/main/java/com/notnoop/apns/internal/BatchApnsService.java
@@ -32,7 +32,9 @@ package com.notnoop.apns.internal;
 
 import static java.util.concurrent.Executors.defaultThreadFactory;
 
+import java.util.Map;
 import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -41,6 +43,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
 import com.notnoop.apns.ApnsNotification;
+import com.notnoop.apns.DeliveryError;
 import com.notnoop.exceptions.NetworkIOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -139,5 +142,10 @@ public class BatchApnsService extends AbstractApnsService {
 				Utilities.close(newConnection);
 			}
 		}
+	}
+
+	@Override
+	public Map<String, Set<DeliveryError>> getDeliveryErrorDevices() {
+		throw new UnsupportedOperationException();
 	}
 }

--- a/src/main/java/com/notnoop/apns/internal/QueuedApnsService.java
+++ b/src/main/java/com/notnoop/apns/internal/QueuedApnsService.java
@@ -32,6 +32,7 @@ package com.notnoop.apns.internal;
 
 import java.util.Date;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Executors;
@@ -43,6 +44,7 @@ import org.slf4j.LoggerFactory;
 
 import com.notnoop.apns.ApnsNotification;
 import com.notnoop.apns.ApnsService;
+import com.notnoop.apns.DeliveryError;
 import com.notnoop.exceptions.NetworkIOException;
 
 public class QueuedApnsService extends AbstractApnsService {
@@ -122,5 +124,10 @@ public class QueuedApnsService extends AbstractApnsService {
     public void testConnection() throws NetworkIOException {
         service.testConnection();
     }
+
+	@Override
+	public Map<String, Set<DeliveryError>> getDeliveryErrorDevices() {
+		throw new UnsupportedOperationException();
+	}
 
 }

--- a/src/test/java/com/notnoop/apns/internal/QueuedApnsServiceTest.java
+++ b/src/test/java/com/notnoop/apns/internal/QueuedApnsServiceTest.java
@@ -33,6 +33,8 @@ package com.notnoop.apns.internal;
 import static org.junit.Assert.*;
 
 import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Semaphore;
 
 import org.junit.Test;
@@ -40,6 +42,7 @@ import static org.mockito.Mockito.*;
 
 import com.notnoop.apns.ApnsNotification;
 import com.notnoop.apns.ApnsService;
+import com.notnoop.apns.DeliveryError;
 import com.notnoop.apns.EnhancedApnsNotification;
 import com.notnoop.exceptions.NetworkIOException;
 
@@ -146,5 +149,10 @@ public class QueuedApnsServiceTest {
         public int getCacheLength() {
             return -1;
         }
+
+		@Override
+		public Map<String, Set<DeliveryError>> getDeliveryErrorDevices() {
+			throw new UnsupportedOperationException();
+		}
     }
 }


### PR DESCRIPTION
I had a need to know what DeliveryErrors I get when trying to do a push notifacation to a device
I added a getDeliveryErrorDevices() method to the ApnsService interface