### PR TITLE
Clarify feedback for enhanced notifications

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -122,6 +122,13 @@ You can use the enhanced notification format to get feedback from Apple about no
 
      service.push(notification);
 
+The feedback is sent to a delegate which has to be registered with the service:
+
+       ApnsService service =
+            APNS.newService()
+            ...
+            .withDelegate(myDelegate)
+            .build();
 
 License
 ----------------


### PR DESCRIPTION
It might be more convenient if the README directly mentions how the feedback for enhanced notifications can be received.

This may save people some time as they do not have to search through the source code.
