### PR TITLE
Add a more robust way to look up TlsTunnel proxy host name

### DIFF
--- a/src/main/java/com/notnoop/apns/internal/TlsTunnelBuilder.java
+++ b/src/main/java/com/notnoop/apns/internal/TlsTunnelBuilder.java
@@ -90,10 +90,10 @@ public final class TlsTunnelBuilder {
             ProxyClient client = new ProxyClient();
             client.getParams().setParameter("http.useragent", "java-apns");
             client.getHostConfiguration().setHost(host, port);
-            String proxyHost = proxyAddress.getAddress().toString().substring(0, proxyAddress.getAddress().toString().indexOf("/"));
-            client.getHostConfiguration().setProxy(proxyHost, proxyAddress.getPort());
             
-        
+            String proxyHost = Utilities.getHostOrIp(proxyAddress);
+            client.getHostConfiguration().setProxy(proxyHost, proxyAddress.getPort());
+
             ProxyClient.ConnectResponse response = client.connect();
             socket = response.getSocket();
             if (socket == null) {
@@ -102,7 +102,7 @@ public final class TlsTunnelBuilder {
                 if(method.getStatusLine().getStatusCode() == 407) {
                     // Proxy server returned 407. We will now try to connect with auth Header
                     if(proxyUsername != null && proxyPassword != null) {
-                        socket = AuthenticateProxy(method, client,proxyHost, proxyAddress.getPort(),
+                        socket = AuthenticateProxy(method, client, proxyHost, proxyAddress.getPort(),
                                 proxyUsername, proxyPassword);
                     } else {
                         throw new ProtocolException("Socket not created: " + method.getStatusLine()); 

--- a/src/test/java/com/notnoop/apns/internal/UtilitiesTest.java
+++ b/src/test/java/com/notnoop/apns/internal/UtilitiesTest.java
@@ -31,7 +31,12 @@
 package com.notnoop.apns.internal;
 
 import org.junit.Assert;
+import static org.junit.Assert.assertTrue;
 import org.junit.Test;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ProtocolException;
 
 public class UtilitiesTest {
 
@@ -83,5 +88,22 @@ public class UtilitiesTest {
             Assert.assertArrayEquals(expected_NFD, bytes);
         }
 
+    }
+
+    @Test
+    public void testHostOrIpLoopback() throws IOException {
+        String hostname = Utilities.getHostOrIp(new InetSocketAddress("127.0.0.1", 8080));
+        assertTrue("getHostOrIp", "127.0.0.1".equals(hostname));
+    }
+
+    @Test(expected = ProtocolException.class)
+    public void testHostOrIpInvalidHost() throws IOException {
+        Utilities.getHostOrIp(new InetSocketAddress("someveryveryveryv3ryveryv3ryveryveryv3rylonginvalidhostname", 8080));
+    }
+
+    @Test
+    public void testHostOrIpValidHost() throws IOException {
+        String hostname = Utilities.getHostOrIp(new InetSocketAddress("example.org", 8080));
+        assertTrue("getHostOrIp", "example.org".equals(hostname));
     }
 }


### PR DESCRIPTION
This fixes and issue where `InetAddress.toString()` may return a result in the
form of `"<empty>/ip-address"`. It is not guaranteed that a host name will always
be resolved here, therefore this may eventually lead to incorrect proxy address
(an empty string basically) being used when constructing the TlsTunnel.

See [InetAddress.html#toString](http://download.java.net/jdk7/archive/b123/docs/api/java/net/InetAddress.html#toString())

In my test case, due to failing DNS lookup, the `InetAddress.toString()` was
always returning `"/10.1.1.5"` which led to proxy connection failure. This must
not be the case. The TlsTunnel should use the ip address if a host name lookup
had failed.

This probably also addresses #285.